### PR TITLE
update zprint to 0.5.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,3 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/clojurescript {:mvn/version "1.10.520"}
-        zprint                    {:mvn/version "0.4.16"}}}
+        zprint                    {:mvn/version "0.5.3"}}}


### PR DESCRIPTION
Enables usage of the following additions: https://github.com/kkinnear/zprint/releases/tag/0.5.0